### PR TITLE
routine compile volume locking fix

### DIFF
--- a/compile/routine.c
+++ b/compile/routine.c
@@ -47,6 +47,7 @@
 #include "error.h"                              // and the error defs
 #include "opcodes.h"                            // and the opcodes
 #include "compile.h"				// compile stuff
+#include "database.h"                           // volume stuff
 
 // function routine entered with source_ptr pointing at the source
 // to evaluate and comp_ptr pointing at where to put the code.
@@ -436,7 +437,8 @@ int Compile_Routine(mvar *rou, mvar *src, u_char *stack)
 	      same = 1;				// same rou and source
   }						// end source ssvn check
   if (!partab.checkonly)			// if it's a real compile
-  { s = SemOp(SEM_ROU, -systab->maxjob);	// grab the routine semaphore
+  { volnum = rou->volset;                       // set volume
+    s = SemOp(SEM_ROU, -systab->maxjob);	// grab the routine semaphore
     if (s < 0) return s;			// if we got an error, quit
     rou_slen  = rou->slen;			// save routine key size
     rou_nsubs = rou->nsubs;
@@ -711,3 +713,5 @@ int Compile_Routine(mvar *rou, mvar *src, u_char *stack)
   i = SemOp(SEM_ROU, systab->maxjob);		// release sem
   return j;					// NEED MORE HERE
 }
+
+/* vim:set ts=8 sw=8 et: */

--- a/runtime/runtime_run.c
+++ b/runtime/runtime_run.c
@@ -2130,7 +2130,7 @@ short run(long savasp, long savssp)		// run compiled code
 	if (var->name.var_cu[0] == '$') 	// dest is ssvn
 	{ if (toupper(var->name.var_cu[1]) != 'R')
 	    ERROR(-ERRM29)			// must be ^$R()
-          i = var2->volset;                     // check volume
+          i = var->volset;                      // check volume
           if (0 == i)                           // no VOL?
           { i = partab.jobtab->rvol;            //   use ROUTINE_VOL
           }

--- a/util/util_share.c
+++ b/util/util_share.c
@@ -155,12 +155,16 @@ pid_t mypid = 0;
 extern void mv1_log_init();
 
 short SemOpEx(int sem_num, int numb,
-              const char *file, int line)        // Add/Remove semaphore
+              const char *file, int line)       // Add/Remove semaphore
 { short s;                                      // for returns
   int i;                                        // for try loop
   char msg[128];
 
   ASSERT((volnum > -1) && (volnum < MAX_VOL+1));// valid volume
+  if (volnum)
+  { ASSERT(NULL != systab->vol[volnum-1]->vollab);   // volume mounted
+  }
+  // fprintf(stderr,"%s:%d @%d=%d/%d curr=%d\r\n",file,line,volnum,sem_num,numb,curr_sem[sem_num][volnum]);
 
   sem_file = file;
   sem_line = line;


### PR DESCRIPTION
If you compiled a routine in other volume than the 1st, the engine locked the wrong volume.