### PR TITLE
fixed global translation, added TRANVAR in ^$SYSTEM

### DIFF
--- a/doc/manual.md
+++ b/doc/manual.md
@@ -137,9 +137,16 @@ the system parameter *ZOTDATA* to 1. By default *ZOTDATA* is
 
 ### Translation table
 
-You could map globals with these feature from one volume set/uci to
+You could map globals with these feature from one volume set/UCI to
 another. This is not new, just the implementation is changed. You could
-have up to 256 translations in the table.
+have up to 511 translations in the table.
+
+Setting `^$SYSTEM("TRANVAR")` you could map a global from every UCI.
+For example the following entry will map the `^TMP` global from every
+UCI to the `MGR` UCI.
+
+    SET ^$SYSTEM("TRANTAB",1)="^[""MGR""]TMP=^TMP"
+    SET ^$SYSTEM("TRANVAR")=1
 
 
 ### Volume syncing
@@ -796,6 +803,7 @@ Additional `^$SYSTEM` variables or changed behavior.
 | REPLICA,n,TYPE       | Replica type MANDATORY or OPTIONAL | set with priv |
 | RESTTIME           | Daemon rest time          | no |
 | RESTORE_FILE       | Volume file to restore from backup | set with priv |
+| TRANVAR            | Translate `^VAR` from every UCI | set with priv |
 | TSIZE              | sizeof(time_t)            | no |
 | ZMINSPACE          | Min. free space in blocks | set with priv |
 | ZOTDATA   	     | Zero free blocks          | set with priv |
@@ -867,7 +875,7 @@ MUMPS with commands/functions written in MUMPS
 | Maximum subscript length          | 127                      |
 | Maximum global value size	    | min(block size, 32KB)    |
 | No. of global subscripts	    | 63                       |
-| Global translation table size	    | 255		       |
+| Global translation table size	    | 511		       |
 | Maximum no. of jobs               | 4096                     |
 | Maximum no. of write daemons	    | 10		       |
 | Maximum JOB command length        | 32KB                     |

--- a/include/mumps.h
+++ b/include/mumps.h
@@ -276,7 +276,7 @@ typedef union semun semun_t;
 
 #endif
 
-#define MAX_TRANTAB	        256             // total number of entries
+#define MAX_TRANTAB	        512             // total number of entries+1
 #define MAX_TRANTAB_HASH        (2*MAX_TRANTAB)
 #define TRANTAB_HASH_MASK       (MAX_TRANTAB_HASH-1)
 
@@ -299,6 +299,12 @@ typedef struct __PACKED__ CSTRING 		// our string type
 } cstring;                                      // end counted string
 
 #define MV1_SUBSPOS     1
+
+typedef struct __PACKED__ GVAR                  // ^[UCI,VOL]VAR
+{ var_u name;                                   // variable name
+  u_char volset;                                // volset number
+  u_char uci;                                   // uci#
+} gvar;
 
 typedef struct __PACKED__ MVAR 			// subscripted MUMPS var
 { var_u name;                                   // variable name
@@ -629,6 +635,7 @@ typedef struct __ALIGNED__ SYSTAB              // system tables
   int sem_id;                                   // GBD semaphore id
   int historic;                                 // Enn, tag+off, $NEXT etc
   int precision;                                // decimal precision
+  int TranVAR;                                  // also translate ^VAR
   int max_tt;                                   // max TRANTAB used
   int tthash_empty;                             // empty tthash[]
   trantab tt[MAX_TRANTAB];                      // translation tables

--- a/init/init_start.c
+++ b/init/init_start.c
@@ -277,6 +277,7 @@ int INIT_Start( char *file,                     // database
   share_size = sjlt_size + volset_size;         // shared memory size
   addoff = share_size;                              // where add buff starts
   share_size = share_size + ( addmb * MBYTE );      // and the additional
+  printf("Share total size %d MB.", (share_size + MBYTE - 1) / MBYTE);
 
   shar_mem_id = shmget(shar_mem_key,
                        share_size,
@@ -336,6 +337,7 @@ int INIT_Start( char *file,                     // database
   systab->precision = DEFAULT_PREC;		// decimal precision
   systab->ZMinSpace = DEFAULT_ZMINSPACE;        // Min. Space for Compress()
   systab->ZotData = 0;                          // Kill zeroes data blocks
+  systab->TranVAR = 0;                          // also translate ^VAR
   systab->ZMaxRestTime = DEFAULT_MAXRESTTIME;	// Daemon rest time
   systab->ZRestTime = systab->ZMaxRestTime;
   systab->dgpID = sysid;			// system ID

--- a/runtime/runtime_ssvn.c
+++ b/runtime/runtime_ssvn.c
@@ -329,6 +329,10 @@ short SS_Get(mvar *var, u_char *buf)            // get ssvn data
 
     case 'S':					// $SYSTEM
       if ((nsubs == 1) &&
+	  (strncasecmp( (char *) subs[0]->buf, "tranvar\0", 8) == 0))
+      { return itocstring(buf, systab->TranVAR); // return the value
+      }
+      if ((nsubs == 1) &&
 	  (strncasecmp( (char *) subs[0]->buf, "tsize\0", 6) == 0))
       { return itocstring(buf, sizeof(time_t)); // return the value
       }
@@ -855,6 +859,13 @@ short SS_Set(mvar *var, cstring *data)          // set ssvn data
             (j > (0.9 * systab->vol[0]->vollab->block_size))) // XXX volume?
           return -(ERRMLAST+ERRZ64);
         systab->ZMinSpace = j;
+	return 0;				// and exit
+      }
+
+      if ((nsubs == 1) &&
+	  (strncasecmp( (char *) subs[0]->buf, "tranvar\0", 8) == 0))
+      { j = cstringtoi(data);
+        systab->TranVAR = 0 != j;
 	return 0;				// and exit
       }
 


### PR DESCRIPTION
Traditionally in MV1/MV2 the global translation worked with translating the expanded global variable name. 2 years ago I breaked that with a code change. Now I reverted back to the original behaviour with another ^$SYSTEM switch TRANVAR, which enables also the changed translation introduced 2 years ago.

See the manual for an example.